### PR TITLE
Add Maven Publish Plugin and Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Using a version before v1.1.0 of this dependency can be used and will suffice, as it will already contain Networking, Room and the EmptyStateRecyclerView.
 
 ```groovy
-implementation 'com.github.appwise-labs:AndroidCore:<Latest-Version>'
+implementation 'com.github.wisemen-digital:AndroidCore:<Latest-Version>'
 ```
 
 ---
@@ -40,7 +40,7 @@ In the core module a lot of general extension functions can be found, as well as
 The core can be added by using this dependency. It contains BaseClasses for ViewModel, Fragments, and Activities. Also a lot of extension functions can be found.
 
 ```groovy
-implementation 'com.github.appwise-labs.AndroidCore:core:<Latest-Version>'
+implementation 'com.github.wisemen-digital.AndroidCore:core:<Latest-Version>'
 ```
 
 Don't forget to also add the "navigation-safe-args" plugin to the project level build.gradle
@@ -60,7 +60,7 @@ dependencies {
 Using this module will enable you to use the BaseRestClient object with some default values regarding the RestClient and Interceptors, a lot of which is costumizable.
 
 ```groovy
-implementation 'com.github.appwise-labs.AndroidCore:networking:<Latest-Version>'
+implementation 'com.github.wisemen-digital.AndroidCore:networking:<Latest-Version>'
 ```
 
 ---
@@ -72,7 +72,7 @@ implementation 'com.github.appwise-labs.AndroidCore:networking:<Latest-Version>'
 With this Room module you will have access to a BaseRoomDao in which a lot of queries are premade. The BaseRoomDao will expect a BaseEntity, so make sure that your Room Entity extends that.
 
 ```groovy
-implementation 'com.github.appwise-labs.AndroidCore:room:<Latest-Version>'
+implementation 'com.github.wisemen-digital.AndroidCore:room:<Latest-Version>'
 
 kapt 'androidx.room:room-compiler:<Latest-Room-Version>'
 ```
@@ -84,7 +84,7 @@ kapt 'androidx.room:room-compiler:<Latest-Room-Version>'
 [Paging Samples and Information](documentation/PAGING.md)
 
 ```groovy
-implementation 'com.github.appwise-labs.AndroidCore:paging:<Latest-Version>'
+implementation 'com.github.wisemen-digital.AndroidCore:paging:<Latest-Version>'
 ```
 
 ---
@@ -96,7 +96,7 @@ implementation 'com.github.appwise-labs.AndroidCore:paging:<Latest-Version>'
 This module contains a custom view extending from the RecyclerView which can handle different states like Loading, Normal, and Empty.
 
 ```groovy
-implementation 'com.github.appwise-labs.AndroidCore:emptyRecyclerView:<Latest-Version>'
+implementation 'com.github.wisemen-digital.AndroidCore:emptyRecyclerView:<Latest-Version>'
 ```
 
 ---

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -114,7 +114,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 from(components["release"])
 
-                groupId = "com.github.appwise-labs"
+                groupId = "com.github.wisemen-digital"
 
                 artifact(sourceJar)
             }

--- a/data/networking/build.gradle.kts
+++ b/data/networking/build.gradle.kts
@@ -66,7 +66,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 from(components["release"])
 
-                groupId = "com.github.appwise-labs"
+                groupId = "com.github.wisemen-digital"
 
                 artifact(sourceJar)
             }

--- a/data/networking/proxyman/build.gradle.kts
+++ b/data/networking/proxyman/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("android")
+    `maven-publish`
 
     id("com.android.library")
 }
@@ -51,4 +52,23 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.junit.ext)
     androidTestImplementation(libs.espresso.core)
+}
+
+val sourceJar by tasks.creating(Jar::class) {
+    from(android.sourceSets["main"].java.srcDirs)
+//    classifier("sources")
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+
+                groupId = "com.github.appwise-labs"
+
+                artifact(sourceJar)
+            }
+        }
+    }
 }

--- a/data/networking/proxyman/build.gradle.kts
+++ b/data/networking/proxyman/build.gradle.kts
@@ -65,7 +65,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 from(components["release"])
 
-                groupId = "com.github.appwise-labs"
+                groupId = "com.github.wisemen-digital"
 
                 artifact(sourceJar)
             }

--- a/data/paging/build.gradle.kts
+++ b/data/paging/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.google.devtools.ksp")
 }
 
-group = "com.github.appwise-labs"
+group = "com.github.wisemen-digital"
 
 android {
     compileSdk = 35
@@ -59,7 +59,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 from(components["release"])
 
-                groupId = "com.github.appwise-labs"
+                groupId = "com.github.wisemen-digital"
 
                 artifact(sourceJar)
             }

--- a/data/room/build.gradle.kts
+++ b/data/room/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.google.devtools.ksp")
 }
 
-group = "com.github.appwise-labs"
+group = "com.github.wisemen-digital"
 
 android {
     compileSdk = 35
@@ -61,7 +61,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 from(components["release"])
 
-                groupId = "com.github.appwise-labs"
+                groupId = "com.github.wisemen-digital"
 
                 artifact(sourceJar)
             }

--- a/documentation/CORE.md
+++ b/documentation/CORE.md
@@ -20,7 +20,7 @@ functions can be found.
 ```groovy
 dependencies {
     ...
-    implementation 'com.github.appwise-labs.AndroidCore:core:<Latest-Version>'
+    implementation 'com.github.wisemen-digital.AndroidCore:core:<Latest-Version>'
 }
 ```
 

--- a/documentation/NETWORKING.md
+++ b/documentation/NETWORKING.md
@@ -16,8 +16,7 @@ The `Networking` module contains base classes and extensions to add Networking (
 
 ```groovy
 dependencies {
-    ...
-    implementation 'com.github.appwise-labs.AndroidCore:networking:<Latest-Version>'
+    implementation 'com.github.wisemen-digital.AndroidCore:networking:<Latest-Version>'
 }
 ```
 

--- a/documentation/PAGING.md
+++ b/documentation/PAGING.md
@@ -12,8 +12,7 @@ The `Paging` module contains some base classes that will enable you to use a sta
 
 ```groovy
 dependencies {
-  ...
-  implementation 'com.github.appwise-labs.AndroidCore:paging:<Latest-Version>'
+  implementation 'com.github.wisemen-digital.AndroidCore:paging:<Latest-Version>'
 }
 ```
 

--- a/documentation/ROOM.md
+++ b/documentation/ROOM.md
@@ -14,8 +14,7 @@ The `Room` module contains some base classes that will enable you to use a stand
 
 ```groovy
 dependencies {
-  ...
-  implementation 'com.github.appwise-labs.AndroidCore:room:<Latest-Version>'
+  implementation 'com.github.wisemen-digital.AndroidCore:room:<Latest-Version>'
 
   kapt "androidx.room:room-compiler:<Latest-Room-Version>"
 }

--- a/list/emptyRecyclerView/build.gradle.kts
+++ b/list/emptyRecyclerView/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("com.android.library")
 }
 
-group = "com.github.appwise-labs"
+group = "com.github.wisemen-digital"
 
 android {
     compileSdk = 35
@@ -54,7 +54,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 from(components["release"])
 
-                groupId = "com.github.appwise-labs"
+                groupId = "com.github.wisemen-digital"
 
                 artifact(sourceJar)
             }

--- a/views/dataRow/build.gradle.kts
+++ b/views/dataRow/build.gradle.kts
@@ -55,7 +55,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 from(components["release"])
 
-                groupId = "com.github.appwise-labs"
+                groupId = "com.github.wisemen-digital"
 
                 artifact(sourceJar)
             }


### PR DESCRIPTION
Adds the `maven-publish` plugin to the `proxyman` module. Configures the plugin to publish a release artifact to a Maven repository with the group ID `com.github.appwise-labs`. Creates a source JAR and includes it as an additional artifact.